### PR TITLE
ci: use ubuntu-latest instead of retired ubuntu-20.04 runner

### DIFF
--- a/.github/workflows/smoke.yaml
+++ b/.github/workflows/smoke.yaml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   main:
     timeout-minutes: 8
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Setup BATS
         uses: mig4/setup-bats@v1

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   main:
     timeout-minutes: 8
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
The Unit and Smoke workflows pinned `runs-on: ubuntu-20.04`. GitHub retired the ubuntu-20.04 hosted runner image in 2025, so every job requesting that label now sits in `queued` forever with no runner assigned and is eventually cancelled — no PR check ever completes.

This is why CI appears not to run on Dependabot PRs: it actually affects every same-repo PR, and Dependabot's are simply the only recent PRs. Switching to ubuntu-latest lets the jobs pick up a runner and run to completion again.