### PR TITLE
fix: repair failing smoke-test docker build (Poetry 2.x + pkg_resources)

### DIFF
--- a/examples/hello-world-flask/Dockerfile
+++ b/examples/hello-world-flask/Dockerfile
@@ -9,10 +9,17 @@ ENV PYTHONFAULTHANDLER=1 \
   PIP_NO_CACHE_DIR=off \
   PIP_DISABLE_PIP_VERSION_CHECK=on \
   PIP_DEFAULT_TIMEOUT=100 \
-  POETRY_VERSION=1.3.2
+  POETRY_VERSION=2.4.1 \
+  POETRY_HOME=/opt/poetry
 
 # This project is poetic.
-RUN pip install "poetry==$POETRY_VERSION"
+# Install Poetry in its own virtualenv so that installing the project's deps
+# (with virtualenvs.create=false, i.e. into the system env) can't downgrade
+# Poetry's own dependencies out from under it. Symlink the entrypoint only so
+# the app still runs under the system `python`.
+RUN python -m venv "$POETRY_HOME" \
+  && "$POETRY_HOME/bin/pip" install "poetry==$POETRY_VERSION" \
+  && ln -s "$POETRY_HOME/bin/poetry" /usr/local/bin/poetry
 # This image is single purpose, so we won't need to compartmentalize Py deps in virtualenvs.
 RUN poetry config virtualenvs.create false
 
@@ -23,7 +30,9 @@ RUN poetry install
 
 # Copy the examples into the image and install deps.
 COPY examples/ ./examples/
-RUN cd ./examples/hello-world-flask && poetry install
+# The example is an app, not a package, so skip installing it as a root package
+# (Poetry 2.x errors on this instead of warning); its deps are still installed.
+RUN cd ./examples/hello-world-flask && poetry install --no-root
 
 # From this point forward, we're operating on the flask example.
 WORKDIR /app/examples/hello-world-flask

--- a/examples/hello-world/Dockerfile
+++ b/examples/hello-world/Dockerfile
@@ -9,9 +9,16 @@ ENV PYTHONFAULTHANDLER=1 \
   PIP_NO_CACHE_DIR=off \
   PIP_DISABLE_PIP_VERSION_CHECK=on \
   PIP_DEFAULT_TIMEOUT=100 \
-  POETRY_VERSION=1.3.2
+  POETRY_VERSION=2.4.1 \
+  POETRY_HOME=/opt/poetry
 
-RUN pip install "poetry==$POETRY_VERSION"
+# Install Poetry in its own virtualenv so that installing the project's deps
+# (with virtualenvs.create=false, i.e. into the system env) can't downgrade
+# Poetry's own dependencies out from under it. Symlink the entrypoint only so
+# the app still runs under the system `python`.
+RUN python -m venv "$POETRY_HOME" \
+  && "$POETRY_HOME/bin/pip" install "poetry==$POETRY_VERSION" \
+  && ln -s "$POETRY_HOME/bin/poetry" /usr/local/bin/poetry
 # This image is single purpose, so we won't need to compartmentalize Py deps in virtualenvs.
 RUN poetry config virtualenvs.create false
 
@@ -21,7 +28,9 @@ RUN poetry install
 
 # Copy the examples into the image and install deps.
 COPY examples/ ./examples/
-RUN cd ./examples/hello-world && poetry install
+# The example is an app, not a package, so skip installing it as a root package
+# (Poetry 2.x errors on this instead of warning); its deps are still installed.
+RUN cd ./examples/hello-world && poetry install --no-root
 
 # From this point forward, we're operating on the example app.
 WORKDIR /app/examples/hello-world

--- a/src/hyperdx/opentelemetry/version.py
+++ b/src/hyperdx/opentelemetry/version.py
@@ -1,2 +1,3 @@
-import pkg_resources
-__version__ = pkg_resources.get_distribution('hyperdx-opentelemetry').version
+from importlib.metadata import version
+
+__version__ = version('hyperdx-opentelemetry')


### PR DESCRIPTION
The `Smoke` workflow was failing on `main` at `docker compose up --build`: the example Dockerfiles pinned Poetry `1.3.2`, which can't install from the committed lock file (lock-version 2.1, generated by Poetry 2.4.1) and died on `poetry install`. This bumps Poetry to `2.4.1` and installs it in an isolated virtualenv so that installing project deps (with `virtualenvs.create=false`) can't downgrade Poetry's own dependencies out from under it, and switches the example-app installs to `poetry install --no-root` since they aren't packages (Poetry 2.x errors instead of warning). It also replaces the removed `pkg_resources` API in `version.py` with `importlib.metadata`, because the example install pulls setuptools ≥ 81 (which no longer ships `pkg_resources`) and the app crashed at runtime. Verified locally: both example images build, the app runs, and the collector receives the expected `hello`/`world` spans and `sheep` metric (all four gRPC smoke assertions pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)