### PR TITLE
ci: add hyperdxio org-wide reusable workflow caller stubs

### DIFF
--- a/.github/workflows/deep-review.yml
+++ b/.github/workflows/deep-review.yml
@@ -1,0 +1,22 @@
+name: Deep Code Review
+on:
+  pull_request_target:
+    types: [opened, synchronize, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to review
+        required: true
+        type: string
+jobs:
+  deep-review:
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    uses: hyperdxio/.github/.github/workflows/deep-review.yml@main
+    with:
+      pr_number: ${{ inputs.pr_number }} # empty on PR events; the workflow falls back to the PR event
+    secrets: inherit

--- a/.github/workflows/deep-review.yml
+++ b/.github/workflows/deep-review.yml
@@ -19,4 +19,5 @@ jobs:
     uses: hyperdxio/.github/.github/workflows/deep-review.yml@main
     with:
       pr_number: ${{ inputs.pr_number }} # empty on PR events; the workflow falls back to the PR event
-    secrets: inherit
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/external-contributor-alerts.yml
+++ b/.github/workflows/external-contributor-alerts.yml
@@ -10,4 +10,5 @@ jobs:
       issues: write
       pull-requests: write
     uses: hyperdxio/.github/.github/workflows/external-contributor-alerts.yml@main
-    secrets: inherit
+    secrets:
+      SLACK_WEBHOOK_OSS_PRS: ${{ secrets.SLACK_WEBHOOK_OSS_PRS }}

--- a/.github/workflows/external-contributor-alerts.yml
+++ b/.github/workflows/external-contributor-alerts.yml
@@ -1,0 +1,13 @@
+name: Alert on external contributions
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+jobs:
+  alert:
+    permissions:
+      issues: write
+      pull-requests: write
+    uses: hyperdxio/.github/.github/workflows/external-contributor-alerts.yml@main
+    secrets: inherit

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -18,4 +18,5 @@ jobs:
     uses: hyperdxio/.github/.github/workflows/pr-triage.yml@main
     with:
       pr_number: ${{ inputs.pr_number }}
-    secrets: inherit
+    secrets:
+      DOTGITHUB_READ_TOKEN: ${{ secrets.DOTGITHUB_READ_TOKEN }}

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -1,0 +1,21 @@
+name: PR Triage
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to classify (leave blank to classify all open PRs)
+        required: false
+        type: string
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    uses: hyperdxio/.github/.github/workflows/pr-triage.yml@main
+    with:
+      pr_number: ${{ inputs.pr_number }}
+    secrets: inherit


### PR DESCRIPTION
Adds caller stubs for the three reusable workflows defined in `hyperdxio/.github`: **Deep Code Review**, **external-contributor alerts**, and **PR Triage**. Each stub under `.github/workflows/` owns its triggers/permissions and calls the org reusable workflow via `uses: hyperdxio/.github/.github/workflows/*.yml@main` with `secrets: inherit`, so CI behaves identically across the org. They require org-level setup before they run — org secrets `ANTHROPIC_API_KEY`, `SLACK_WEBHOOK_OSS_PRS`, and `DOTGITHUB_READ_TOKEN`, plus reusable-workflow access enabled on the private `hyperdxio/.github` repo — and are safe to merge without it (they fail/no-op rather than breaking existing CI). Note PR Triage's critical/trivial *file* heuristics target the TS monorepo layout, so on this Python repo tiering falls back to line-count signals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)