### PR TITLE
ci: move release job off retired ubuntu-20.04 runner

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ concurrency:
 jobs:
   build-and-publish-to-pypi:
     timeout-minutes: 8
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Releases can schedule again. GitHub fully retired the `ubuntu-20.04` hosted runner image on 2025-04-15, so the `build-and-publish-to-pypi` job stopped running entirely. This switches it to `ubuntu-latest`, completing the migration in 1f79b61 that covered the unit and smoke workflows but left `release.yaml` behind.

This restores the runner, not the release path end to end. The workflow still triggers on every push to `main` and publishes whatever version is in `pyproject.toml`, so it will now reach the upload step and fail there until the version is bumped past the 0.3.0 already on PyPI.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
