### PR TITLE
chore(release): 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # hyperdx-opentelemetry-python changelog
 
+## [0.4.0] - 2026-07-27
+
+### Enhancements
+
+- Relax OpenTelemetry constraints to ranges (#41) — `opentelemetry-{api,sdk,exporter-otlp}` move from `==1.30.0` to `>=1.30.0,<2.0.0` and `opentelemetry-instrumentation` from `==0.51b0` to `>=0.51b0,<1.0.0`, so the distro can be co-installed with other OpenTelemetry-based libraries that require a newer core
+
+### Fixes
+
+- Repair smoke-test docker build and `pkg_resources` runtime error (#40)
+- Pin `setuptools >= 78.1.1` (#37)
+
+### Maintenance
+
+- ci: move release job off retired ubuntu-20.04 runner (#43)
+- ci: forward only required secrets to reusable workflows (#42)
+- ci: add hyperdxio org-wide reusable workflow caller stubs (#42)
+- ci: use ubuntu-latest instead of retired ubuntu-20.04 runner (#38)
+- chore(deps): bump idna from 3.10 to 3.15 (#39)
+- chore(deps): bump protobuf from 5.29.3 to 5.29.6 (#36)
+
+Note: releases 0.3.0b0, 0.3.0, and 0.2.0 were published without changelog entries. This entry covers changes since 0.3.0 only.
+
 ## [0.2.1b0] - 2023-05-16
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,71 @@
 - chore(deps): bump idna from 3.10 to 3.15 (#39)
 - chore(deps): bump protobuf from 5.29.3 to 5.29.6 (#36)
 
-Note: releases 0.3.0b0, 0.3.0, and 0.2.0 were published without changelog entries. This entry covers changes since 0.3.0 only.
+## [0.3.0] - 2025-03-06
+
+Promotes 0.3.0b0 to a stable release. No functional change.
+
+### Maintenance
+
+- chore: release 0.3.0 (#27)
+
+## [0.3.0b0] - 2025-02-24
+
+### Enhancements
+
+- Update OpenTelemetry packages to 1.30.0/0.51b0 (#26)
+
+### Breaking changes
+
+- Drop Python 3.8. The minimum supported version moves from `>= 3.8` to `>= 3.9` (#26)
+
+### Maintenance
+
+- Add `setuptools ^75.8.0` as a direct dependency (#26)
+- Add the GitHub Actions release workflow that publishes to PyPI (#26)
+- docs: update README
+
+## [0.2.0] - 2024-10-31
+
+### Enhancements
+
+- Update OpenTelemetry packages to 1.27.0/0.48b0 (#24)
+
+### Breaking changes
+
+- Drop Python 3.7. The minimum supported version moves from `^3.7, >= 3.7.2` to `>= 3.8` (#24)
+
+### Maintenance
+
+- Move off the deprecated `docker-compose` v1 CLI to `docker compose` across the Makefile, smoke tests, and docs (#24)
+- docs: update README
+
+## [0.1.0] - 2024-02-16
+
+### Enhancements
+
+- Update OpenTelemetry packages to 1.22.0/0.43b0 (#19)
+
+### Maintenance
+
+- Set up CI with unit and smoke test workflows (#19)
+- Add a Django example app, and expand the hello-world and Flask examples (#19)
+- Add `release.sh` release helper script
+- maint(deps-dev): bump pytest from 7.3.1 to 7.4.4 (#14)
+- maint(deps-dev): bump pylint from 2.17.3 to 2.17.7 (#11)
+- maint(deps-dev): bump requests-mock from 1.10.0 to 1.11.0 (#1)
+
+## [0.0.5] - 2023-09-20
+
+### Enhancements
+
+- Update OpenTelemetry packages to 1.19.0/0.40b0
+
+---
+
+Entries below this line predate the HyperDX release series and use the version
+numbering of the upstream Honeycomb distro this project was derived from. The
+HyperDX releases 0.0.1 through 0.0.4 are not recorded.
 
 ## [0.2.1b0] - 2023-05-16
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hyperdx-opentelemetry"
-version = "0.3.0"
+version = "0.4.0"
 description = "HyperDX OpenTelemetry Distro for Python"
 authors = ["HyperDX <support@hyperdx.io>"]
 readme = "README.md"


### PR DESCRIPTION
Bumping to 0.4.0 unblocks PyPI publishing. After #43 the Release job actually runs, but it now fails at the upload step with `400 File already exists` because 0.3.0 is already on PyPI; merging this publishes 0.4.0 automatically.

Minor rather than patch: #41 relaxed the OpenTelemetry constraints from exact pins to ranges, so the distro can be co-installed with other OpenTelemetry-based libraries that require a newer core.

This also backfills the changelog, which had recorded nothing since 2023. Entries for 0.0.5, 0.1.0, 0.2.0, 0.3.0b0 and 0.3.0 are reconstructed from git history (OpenTelemetry bumps, the Python 3.7 and 3.8 drops, notable maintenance), and a separator marks where the older Honeycomb-lineage entries begin, since those use a different numbering scheme and are why 0.2.1b0 is dated earlier than 0.0.5. HyperDX 0.0.1 through 0.0.4 remain unrecorded.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_5_%281M%29-D97757?logo=claude&logoColor=white)
